### PR TITLE
Fix error when dumping all records for model (without constraints)

### DIFF
--- a/lib/evil_seed/root_dumper.rb
+++ b/lib/evil_seed/root_dumper.rb
@@ -23,7 +23,9 @@ module EvilSeed
     # @param output [IO] Stream to write SQL dump into
     def call
       association_path = model_class.model_name.singular
-      RelationDumper.new(model_class.where(*root.constraints), self, association_path).call
+      relation = model_class.all
+      relation = relation.where(*root.constraints) if root.constraints.any? # without arguments returns not a relation
+      RelationDumper.new(relation, self, association_path).call
     end
 
     # @return [Boolean] +true+ if limits are NOT reached and +false+ otherwise

--- a/test/evil_seed_test.rb
+++ b/test/evil_seed_test.rb
@@ -11,6 +11,9 @@ class EvilSeedTest < Minitest::Test
         root.exclude(/parent\.users/)
         root.exclude(/role\..+/)
       end
+      config.root('Question') do |root|
+        root.exclude(/.*/)
+      end
     end
   end
 


### PR DESCRIPTION
When you add to configuration root without constraints (like it is in README):

```ruby
config.root("Role") do |root|
  root.exclude(/.*/)
end
```

You will get following error:

    NoMethodError: undefined method `klass' for #<ActiveRecord::QueryMethods::WhereChain:0x007f94e35865e0>
    /Users/anovikov/Code/evil-seed/lib/evil_seed/relation_dumper.rb:30:in `initialize'
    /Users/anovikov/Code/evil-seed/lib/evil_seed/root_dumper.rb:26:in `new'
    /Users/anovikov/Code/evil-seed/lib/evil_seed/root_dumper.rb:26:in `call'
    /Users/anovikov/Code/evil-seed/lib/evil_seed/dumper.rb:23:in `block in call'
    /Users/anovikov/Code/evil-seed/lib/evil_seed/dumper.rb:22:in `each'
    /Users/anovikov/Code/evil-seed/lib/evil_seed/dumper.rb:22:in `call'
    /Users/anovikov/Code/evil-seed/lib/evil_seed.rb:25:in `dump'

¯\_(ツ)_/¯